### PR TITLE
Add CKEditor for news editing

### DIFF
--- a/resources/views/admin/news/create.blade.php
+++ b/resources/views/admin/news/create.blade.php
@@ -10,8 +10,20 @@
         </div>
         <div>
             <label class="block text-sm font-medium text-gray-700">Content</label>
-            <textarea name="content" rows="5" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"></textarea>
+            <textarea id="content-editor" name="content" rows="5" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"></textarea>
         </div>
         <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Save</button>
     </form>
+@push('scripts')
+    <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/classic/ckeditor.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            ClassicEditor
+                .create(document.querySelector('#content-editor'))
+                .catch(error => {
+                    console.error(error);
+                });
+        });
+    </script>
+@endpush
 @endsection

--- a/resources/views/admin/news/edit.blade.php
+++ b/resources/views/admin/news/edit.blade.php
@@ -11,8 +11,20 @@
         </div>
         <div>
             <label class="block text-sm font-medium text-gray-700">Content</label>
-            <textarea name="content" rows="5" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">{{ $news->content }}</textarea>
+            <textarea id="content-editor" name="content" rows="5" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">{{ $news->content }}</textarea>
         </div>
         <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Save</button>
     </form>
+@push('scripts')
+    <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/classic/ckeditor.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            ClassicEditor
+                .create(document.querySelector('#content-editor'))
+                .catch(error => {
+                    console.error(error);
+                });
+        });
+    </script>
+@endpush
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,5 +9,6 @@
     <div class="container mx-auto p-4">
         @yield('content')
     </div>
+    @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable per-view scripts in the layout
- load CKEditor from CDN on news creation and edit forms

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6884cc56d790832a97673ae8ad15fcaf