### PR TITLE
Add XML product importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/node_modules/
+.env
+.phpunit.result.cache

--- a/app/Console/Commands/ImportProducts.php
+++ b/app/Console/Commands/ImportProducts.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class ImportProducts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:products';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import products from products_feed.xml';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $path = base_path('products_feed.xml');
+        if (! file_exists($path)) {
+            $this->error('products_feed.xml not found');
+            return Command::FAILURE;
+        }
+
+        $xml = simplexml_load_file($path);
+        if (! $xml) {
+            $this->error('Unable to parse XML');
+            return Command::FAILURE;
+        }
+
+        // import categories
+        if (isset($xml->shop->categories->category)) {
+            foreach ($xml->shop->categories->category as $categoryNode) {
+                \App\Models\Category::updateOrCreate(
+                    ['id' => (int) $categoryNode['id']],
+                    [
+                        'parent_id' => $categoryNode['parentId'] ? (int) $categoryNode['parentId'] : null,
+                        'name' => trim((string) $categoryNode),
+                    ]
+                );
+            }
+        }
+
+        // import offers
+        if (isset($xml->shop->offers->offer)) {
+            foreach ($xml->shop->offers->offer as $offer) {
+                $pictures = [];
+                foreach ($offer->picture as $pic) {
+                    $pictures[] = (string) $pic;
+                }
+
+                $params = [];
+                foreach ($offer->param as $param) {
+                    $params[(string) $param['name']] = trim((string) $param);
+                }
+
+                \App\Models\Product::updateOrCreate(
+                    ['xml_id' => (int) $offer['id']],
+                    [
+                        'available' => ((string) $offer['available']) === 'true',
+                        'url' => (string) $offer->url,
+                        'price' => (float) $offer->price,
+                        'currency' => (string) $offer->currencyId,
+                        'category_id' => (int) $offer->categoryId,
+                        'pictures' => $pictures,
+                        'pickup' => $offer->pickup ? ((string) $offer->pickup) === 'true' : null,
+                        'delivery' => $offer->delivery ? ((string) $offer->delivery) === 'true' : null,
+                        'name' => (string) $offer->name,
+                        'name_ua' => (string) $offer->name_ua ?: null,
+                        'vendor' => (string) $offer->vendor ?: null,
+                        'description' => (string) $offer->description ?: null,
+                        'description_ua' => (string) $offer->description_ua ?: null,
+                        'params' => $params ?: null,
+                    ]
+                );
+            }
+        }
+
+        $this->info('Import completed');
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    /**
+     * The primary key type is non-incrementing.
+     */
+    public $incrementing = false;
+
+    protected $keyType = 'integer';
+
+    protected $fillable = [
+        'id',
+        'parent_id',
+        'name',
+    ];
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children()
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    protected $fillable = [
+        'xml_id',
+        'available',
+        'url',
+        'price',
+        'currency',
+        'category_id',
+        'pictures',
+        'pickup',
+        'delivery',
+        'name',
+        'name_ua',
+        'vendor',
+        'description',
+        'description_ua',
+        'params',
+    ];
+
+    protected $casts = [
+        'available' => 'boolean',
+        'pickup' => 'boolean',
+        'delivery' => 'boolean',
+        'pictures' => 'array',
+        'params' => 'array',
+    ];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/database/migrations/2025_07_26_213629_create_categories_table.php
+++ b/database/migrations/2025_07_26_213629_create_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->unsignedBigInteger('id')->primary();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->string('name');
+            $table->timestamps();
+
+            $table->foreign('parent_id')
+                ->references('id')
+                ->on('categories')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_07_26_213631_create_products_table.php
+++ b/database/migrations/2025_07_26_213631_create_products_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('xml_id')->unique();
+            $table->boolean('available');
+            $table->string('url');
+            $table->decimal('price', 10, 2);
+            $table->string('currency', 10);
+            $table->unsignedBigInteger('category_id');
+            $table->json('pictures')->nullable();
+            $table->boolean('pickup')->nullable();
+            $table->boolean('delivery')->nullable();
+            $table->string('name');
+            $table->string('name_ua')->nullable();
+            $table->string('vendor')->nullable();
+            $table->text('description')->nullable();
+            $table->text('description_ua')->nullable();
+            $table->json('params')->nullable();
+            $table->timestamps();
+
+            $table->foreign('category_id')
+                ->references('id')
+                ->on('categories')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};


### PR DESCRIPTION
## Summary
- ignore vendor and other local files
- create migrations for categories and products
- add models for `Category` and `Product`
- implement `import:products` artisan command for loading `products_feed.xml`

## Testing
- `composer test`
- `php artisan import:products`


------
https://chatgpt.com/codex/tasks/task_e_688549cbb040832aaf4ea2c4760a6589